### PR TITLE
use geojson endpoint, reverse coordinate order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.8.1
+
+RUN go get github.com/paulmach/go.geojson

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Coordinate Converter
 Coordinate Converter is used to convert coordinates from a JSON http response. Specfically, this program is used at OSU with ARCGIS to convert coordinates to latitude and longitude.
 
+### Dependencies
+
+* github.com/paulmach/go.geojson
+
 ## Usage
 
 ### Run It Locally

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ coordinate-converter -u "$URL" [-f "$FILEPATH"]
 Included is a [docker-compose file](docker-compose.yml) that starts containers for [CS2CS](http://proj4.org/apps/cs2cs.html) and [Golang](https://golang.org) to build the executable. A file called converted-coordinates.json will be created in $PWD when running this command:
 ```
 export URL='www.example.com/arcgisjsonendpoint'
-docker-compose up
+docker-compose up --build
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Coordinate Converter is used to convert coordinates from a JSON http response. S
 
 ### Dependencies
 
-* github.com/paulmach/go.geojson
+* [github.com/paulmach/go.geojson](https://github.com/paulmach/go.geojson)
 
 ## Usage
 

--- a/converter.go
+++ b/converter.go
@@ -105,7 +105,17 @@ func coordinateIterator(buildings *geojson.FeatureCollection, convertedBuildings
                 }
             }
         } else if building.Geometry.Type == "MultiPolygon" {
-            fmt.Println("Todo: Handle MultiPolygon")
+            for polygonIndex, polygon := range building.Geometry.MultiPolygon {
+                for ringIndex, ring := range polygon {
+                    for coordPairIndex, coordpair := range ring  {
+                        convertedLon, convertedLat := convertCoordinates(coordpair[0], coordpair[1])
+
+                        // Reassign coordinate values to the converted coordinates
+                        convertedBuildings.Features[featureIndex].Geometry.MultiPolygon[polygonIndex][ringIndex][(len(ring) - 1) - coordPairIndex][0] = convertedLon
+                        convertedBuildings.Features[featureIndex].Geometry.MultiPolygon[polygonIndex][ringIndex][(len(ring) - 1) - coordPairIndex][1] = convertedLat
+                    }
+                }
+            }
         }
     }
 }

--- a/converter.go
+++ b/converter.go
@@ -70,7 +70,7 @@ func convertCoordinates(lon, lat float64) (float64, float64) {
     lonStr := strconv.FormatFloat(lon, 'f', -1, 64)
     latStr := strconv.FormatFloat(lat, 'f', -1, 64)
 
-    cs2csCommand := "echo \"" + lonStr + " " + latStr + "\" | cs2cs -f %8.6f +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=10.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs +to +proj=longlat +datum=WGS84 +no_defs"
+    cs2csCommand := "echo \"" + lonStr + " " + latStr + "\" | cs2cs -f %8.6f +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs +to +proj=longlat +datum=WGS84 +no_defs"
     cmd := exec.Command("sh", "-c", cs2csCommand)
     stdoutStderr, err := cmd.CombinedOutput()
     check(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 version: '3.1'
+
 services:
   go:
-    image: "golang:1.8.1"
+    build: .
+    image: go-coordinate-converter
     volumes:
-      - $PWD:/usr/src/github.com/osu-mist/coordinate-converter
-    working_dir: /usr/src/github.com/osu-mist/coordinate-converter
+      - $PWD:/go/src/github.com/osu-mist/coordinate-converter
+    working_dir: /go/src/github.com/osu-mist/coordinate-converter
     command: go build -v
   cs2cs:
     image: "osgeo/proj.4"


### PR DESCRIPTION
One of the changes includes using a geojson specific endpoint which, depending on if the geometry is polygon or multipolygon, could have coordinates of a 3 or 4 dimensional array, respectively. I used https://github.com/paulmach/go.geojson to take care of unmarshaling a json body into a featurecollection while using a 3 or 4 dimensional array appropriately

The arcgis geojson endpoint isn't adhering to RFC 7946 standards regarding the right-hand wrap protocol. Specifically, for a given polygon, the first/exerior ring must wrap in a counterclockwise direction while all rings following the first/exterior ring must wrap in a clockwise direction.

Arcgis data was doing the opposite, so I created two data slices containing arcgis data, and reassigned the values for one of them to reverse the direction that the coordinates were layed out in a ring. The order of the rings themselves within a polygon should remain the same, since arcgis is correctly putting the exterior ring first with all interior rings following the first ring.